### PR TITLE
Update plugin name on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gatsby plugin medium feed
+# Gatsby source medium feed
 
 This plugin returns the content of medium posts.
 
@@ -14,13 +14,13 @@ Available properties are:
 
 ## Usage
 
-1. Run `npm i -S gatsby-plugin-medium-feed`
+1. Run `npm i -S gatsby-source-medium-feed`
 1. Add plugin to your `gatsby-config.js` :
 
 ```js
 plugins: [
   {
-    resolve: 'gatsby-plugin-medium-feed',
+    resolve: 'gatsby-source-medium-feed',
     options: {
       userName: '@...', // Medium user name
       name: 'MediumFeed', // GraphQL query AllMediumFeed


### PR DESCRIPTION
Hello :), 

I am not sure if you already have this change in mind, but just in case here it is.

**Changes:**
- Updated the README file, it was keeping the old name of the plugin 

Thanks for creating this plugin 👍.